### PR TITLE
RepoNotRequired: add `version` and `help`

### DIFF
--- a/Use-Git.ps1
+++ b/Use-Git.ps1
@@ -94,7 +94,7 @@
 
         $progId = Get-Random
         $dirCount = 0
-        $RepoNotRequired = 'clone','init'  # A small number of git operations do not require a repo.  List them here.
+        $RepoNotRequired = 'clone','init','version','help'  # A small number of git operations do not require a repo.  List them here.
     }
     process {
         # First, we need to take any input and figure out what directories we are going into.


### PR DESCRIPTION
Adds `version` and `help` to the list git operations that do not require a repo. 

This allows [`posh-git`](https://github.com/dahlbyk/posh-git) to be imported properly without warnings. I'm unsure though if this is unnecessary given the recommendations @StartAutomating gave to @dahlbyk in https://github.com/dahlbyk/posh-git/issues/912.

However, setting `posh-git` aside for a second, I don't think it would hurt to merge this PR since I don't believe `version` and `help` require a repo and it would be annoying to have to `cd` into a repo directory to see my git version.

Example warnings from `posh-git` (version `1.1.0`) and `ugit` (version `0.2.9`) when importing both modules in the same session.

![image](https://user-images.githubusercontent.com/22397984/194387902-791f86ba-d953-486e-afda-d386209e1603.png)

I ran the Tests after making the changes and they passed.

![image](https://user-images.githubusercontent.com/22397984/194388145-2bb3c5c5-0da0-462e-a028-98ce6bb24f4a.png)
