### PR TITLE
ugit 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.3.8:
+
+* Use-Git can now be extended (#140, #97), letting you add PowerShell parameters to any git command
+* Initial input extensions
+  * git.clone.input (#141) (--progress is inferred so Write-Progress happens automagically)
+  * git.log.input (#142) (Added -Before/-After/-Author/-CurrentBranch)
+  * git.commit.input (#144) (Added -Message/-Body/-Title/-Trailer)
+* Other Improvements:
+  * git log will not process --pretty/--format (Fixes #143)
+  * git log now supports .Trailers (Fixes #112)
+  * git remote formatting improved (Fixes #145)
+  * git remote now works for multiple remotes (Fixes #136)
+  * Updated logo (#139)
+
+---
+
 ## 0.3.7:
 
 * git remote

--- a/Extensions/Git.Clone.Input.UGit.Extension.ps1
+++ b/Extensions/Git.Clone.Input.UGit.Extension.ps1
@@ -1,0 +1,19 @@
+<#
+.SYNOPSIS
+    Git Clone extended input
+.DESCRIPTION
+    Extends the input for git clone.
+
+    By default, if --progress is not found, it will be added to any git clone.
+.EXAMPLE
+    git clone https://github.com/MDN/content.git # This is a big repo.  Progress bars will be very welcome.
+#>
+[ValidatePattern('^git clone')]
+[Management.Automation.Cmdlet("Use","Git")]
+[CmdletBinding(PositionalBinding=$false)]
+param(
+)
+
+if ($gitArgument -notcontains '--progress') {
+    '--progress'
+}

--- a/Extensions/Git.Commit.Input.UGit.Extension.ps1
+++ b/Extensions/Git.Commit.Input.UGit.Extension.ps1
@@ -27,7 +27,7 @@ $Body,
 # Any git trailers to add to the commit.
 # git trailers are key-value pairs you can use to associate metadata with a commit.
 # As this uses --trailer, this requires git version 2.33 or greater.
-[Alias('Trailer','Metadata','CommitMetadata','GitMetadata')]
+[Alias('Trailer','CommitMetadata','GitMetadata')]
 [Collections.IDictionary]
 $Trailers,
 

--- a/Extensions/Git.Commit.Input.UGit.Extension.ps1
+++ b/Extensions/Git.Commit.Input.UGit.Extension.ps1
@@ -1,0 +1,66 @@
+<#
+.SYNOPSIS
+    Git Commit Input
+.DESCRIPTION
+    Makes Git Commit easier to use from PowerShell by providing parameters for the -Message, -Title, -Body, and -Trailers
+.EXAMPLE
+    git commit -Title "Fixing Something"
+.EXAMPLE
+    git commit -Title "Changing Stuff" -Trailers @{"Co-Authored-By"="SOMEONE ELSE <Someone@Else.com>"}
+#>
+[ValidatePattern('^git commit')]
+[Management.Automation.Cmdlet('Use','Git')]
+[CmdletBinding(PositionalBinding=$false)]
+param(
+# The message used for the commit
+[string]
+$Message,
+
+# The title of the commit.  If -Message is also provided, this will become part of the -Body
+[string]
+$Title,
+
+# The body of the commit.
+[string]
+$Body,
+
+# Any git trailers to add to the commit.
+# git trailers are key-value pairs you can use to associate metadata with a commit.
+# As this uses --trailer, this requires git version 2.33 or greater.
+[Alias('Trailer','Metadata','CommitMetadata','GitMetadata')]
+[Collections.IDictionary]
+$Trailers,
+
+# If set, will amend an existing commit.
+[switch]
+$Amend
+)
+
+
+
+if ($Message) {
+    "-m"
+    $message
+}
+
+if ($Title) {
+    "-m"
+    $title
+}
+
+if ($Body) {
+    "-m"
+    $body
+}
+
+if ($Trailers) {    
+    foreach ($kv in $Trailers.GetEnumerator()) {
+        foreach ($val in $kv.Value) {
+            "--trailer=$($kv.Key -replace ':','_colon_' -replace '\s', '-')=$val"
+        }        
+    }
+}
+
+if ($amend) {
+    "--amend"   
+}

--- a/Extensions/Git.Log.Input.UGit.Extension.ps1
+++ b/Extensions/Git.Log.Input.UGit.Extension.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+    git log input
+.DESCRIPTION
+    Extends the parameters for git log, making it easier to use from PowerShell.
+
+    Allows timeframe parameters to be tab-completed:
+    * After/Since become --after
+    * Before/Until become --before
+    * Author/Committer become --author
+
+    Adds -CurrentBranch, which gives the changes between the upstream branch and the current branch.
+
+    Also adds -IssueNumber, which searchers for commits that reference particular issues.
+.EXAMPLE
+    git log -CurrentBranch
+#>
+[ValidatePattern('^git log')]
+[Management.Automation.Cmdlet("Use","Git")]
+[CmdletBinding(PositionalBinding=$false)]
+param(
+# Gets logs after a given date
+[DateTime]
+[Alias('Since')]
+$After,
+
+# Gets before a given date
+[DateTime]
+[Alias('Until')]
+$Before,
+
+# Gets lof from a given author or committer
+[Alias('Committer')]
+[string]
+$Author,
+
+# If set, will get all changes between the upstream branch and the current branch.
+[Alias('UpstreamDelta','ThisBranch')]
+[switch]
+$CurrentBranch,
+
+# One or more issue numbers.  Providing an issue number of 0 will find all log entries that reference an issue.
+[Parameter(ValueFromPipelineByPropertyName)]
+[Alias('ReferenceNumbers','ReferenceNumber','IssueNumbers','WorkItemID','WorkItemIDs')]
+[int[]]
+$IssueNumber
+)
+
+foreach ($dashToDoubleDash in 'after', 'before', 'author') {
+    if ($PSBoundParameters[$dashToDoubleDash]) {
+        "--$dashToDoubleDash"
+        "$($PSBoundParameters[$dashToDoubleDash])"
+    }
+}
+
+if ($CurrentBranch) {        
+    $headbranch        = git remote | git remote show | Select-Object -ExpandProperty HeadBranch
+    $currentBranchName = git branch | Where-Object IsCurrentBranch
+    if ($currentBranchName -ne $headbranch) {
+        "$headbranch..$currentBranchName"
+    } else {
+        Write-Warning "On $headBranch"
+    }
+}
+
+if ($IssueNumber) {
+    "--perl-regexp"    
+    foreach ($IssueNum in $IssueNumber) {
+        '--grep'
+        if ($IssueNum -eq 0) {
+            '\#\d+\D'
+        } else {
+            "\#$IssueNum\D"
+        }
+    }
+    
+}

--- a/Extensions/Git.Log.UGit.Extension.ps1
+++ b/Extensions/Git.Log.UGit.Extension.ps1
@@ -113,6 +113,21 @@ begin {
             }
         }
 
+        if ($gitLogOut.CommitMessage) {
+            $gitTrailers = [Ordered]@{}
+            foreach ($commitMessageLine in $gitLogOut.CommitMessage -split '(?>\r\n|\n)') {
+                if ($commitMessageLine -notmatch '\s{0,}(?<k>\S+):\s(?<v>[\s\S]+$)') {
+                    continue
+                }
+                if (-not $gitTrailers[$matches.k]) {
+                    $gitTrailers[$matches.k] = $matches.v
+                } else {
+                    $gitTrailers[$matches.k] = @($gitTrailers[$matches.k]) + $v
+                }                 
+            }
+            $gitLogOut.Trailers = $gitTrailers
+        }
+
         if ($GitArgument -contains '--shortstat' -or $GitArgument -contains '--stat') {
             foreach ($linePart in $OutputLines[-2] -split ',' -replace '[\s\w\(\)-[\d]]') {
                 if ($linePart.Contains('+')) {

--- a/Extensions/Git.Log.UGit.Extension.ps1
+++ b/Extensions/Git.Log.UGit.Extension.ps1
@@ -167,6 +167,9 @@ begin {
 
 
 process {
+    if ($gitCommand -match '--(?>pretty|format)') {
+        continue
+    }
 
     if ("$gitOut" -like 'Commit*' -and $lines) {
         OutGitLog $lines

--- a/Formatting/Git.Remote.format.ps1
+++ b/Formatting/Git.Remote.format.ps1
@@ -20,18 +20,24 @@ Write-FormatView -TypeName Git.Remote.Show -Action {
             [Environment]::NewLine + (' ' * 4)
         )
     }
-    Write-FormatViewExpression -Newline
-    Write-FormatViewExpression -Text '  Remote Branches:'
-    Write-FormatViewExpression -Newline
-    Write-FormatViewExpression -ControlName GitRemoteBranchList -Property RemoteBranches
-    Write-FormatViewExpression -Newline
-    Write-FormatViewExpression -Text '  Local Branches:' 
-    Write-FormatViewExpression -Newline
-    Write-FormatViewExpression -ControlName GitRemoteBranchList -Property LocalBranches
-    Write-FormatViewExpression -Text '  Tracked Upstreams:'
-    Write-FormatViewExpression -Newline
-    Write-FormatViewExpression -ControlName GitRemoteBranchList -Property TrackedUpstreams
-    Write-FormatViewExpression -Newline
+    Write-FormatViewExpression -If { $_.RemoteBranches } -ScriptBlock {
+        [Environment]::NewLine +  '  Remote Branches:' + [Environment]::NewLine
+    }
+
+    Write-FormatViewExpression -If { $_.RemoteBranches } -ControlName GitRemoteBranchList -Property RemoteBranches         
+    
+    Write-FormatViewExpression -If { $_.LocalBranches } -ScriptBlock {
+        [Environment]::NewLine +  '  Local Branches:' + [Environment]::NewLine
+    }
+
+    Write-FormatViewExpression -If { $_.LocalBranches } -ControlName GitRemoteBranchList -Property LocalBranches
+    
+
+    Write-FormatViewExpression -If { $_.TrackedUpstreams } -ScriptBlock {
+        [Environment]::NewLine +  '  Tracked Upstreams:' + [Environment]::NewLine
+    }
+    
+    Write-FormatViewExpression -If { $_.TrackedUpstreams } -ControlName GitRemoteBranchList -Property TrackedUpstreams    
 }
 
 Write-FormatView -TypeName n/a -Name GitRemoteBranchList -AsControl -Action {

--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ It will attempt to locate any output specified by -o and return it as a file or 
     git checkout main
 ~~~
 
+### Git.Clone.Input Example 1
+
+
+~~~PowerShell
+    git clone https://github.com/MDN/content.git # This is a big repo.  Progress bars will be very welcome.
+~~~
+
 ### Git.Clone Example 1
 
 

--- a/README.md
+++ b/README.md
@@ -66,87 +66,10 @@ If this pattern matches the given git command, the extension will run.
 
 Get-UGitExtension is built using [Piecemeal](https://github.com/StartAutomating/Piecemeal)
 
-## Out-Git Extensions
-
-### Git Commands
-
-Most extensions handle output from a single git command.
-
-
-* [Git Branch](docs/Git.Branch-Extension.md)
-
- 
-* [Git Checkout](docs/Git.Checkout-Extension.md)
-
- 
-* [Git Clone](docs/Git.Clone-Extension.md)
-
- 
-* [Git Commit](docs/Git.Commit-Extension.md)
-
- 
-* [Git Diff](docs/Git.Diff-Extension.md)
-
- 
-* [Git FileName](docs/Git.FileName-Extension.md)
-
- 
-* [Git Grep](docs/Git.Grep-Extension.md)
-
- 
-* [Git Help All](docs/Git.Help.All-Extension.md)
-
- 
-* [Git Init](docs/Git.Init-Extension.md)
-
- 
-* [Git Log](docs/Git.Log-Extension.md)
-
- 
-* [Git Mv](docs/Git.Mv-Extension.md)
-
- 
-* [Git Pull](docs/Git.Pull-Extension.md)
-
- 
-* [Git Push](docs/Git.Push-Extension.md)
-
- 
-* [Git RefLog](docs/Git.RefLog-Extension.md)
-
- 
-* [Git Remote](docs/Git.Remote-Extension.md)
-
- 
-* [Git Rm](docs/Git.Rm-Extension.md)
-
- 
-* [Git Shortlog](docs/Git.Shortlog-Extension.md)
-
- 
-* [Git Stash](docs/Git.Stash-Extension.md)
-
- 
-* [Git Status](docs/Git.Status-Extension.md)
-
-
-
-### Additional Output Extensions
-
-A few extensions handle output from any number of git commands, depending on the arguments.
-
-* Git.FileName
-
-This applies to any git command that uses --name-only.
-It will attempt to return the name as a file, or as an object containing the name.
-
-* Git.FileOutput
-
-This applies to an git command that uses the -o flag.
-It will attempt to locate any output specified by -o and return it as a file or directory.
-
-
 ## ugit examples
+
+ugit comes packed with many examples.
+You might want to try giving some of these a try.
 
 ### Git.Branch Example 1
 
@@ -431,5 +354,93 @@ It will attempt to locate any output specified by -o and return it as a file or 
 ~~~PowerShell
     git status | Select-Object -ExpandProperty Untracked
 ~~~
+
+## Out-Git Extensions
+
+### Git Commands
+
+Most extensions handle output from a single git command.
+
+
+* [Git Branch](docs/Git.Branch-Extension.md)
+
+ 
+* [Git Checkout](docs/Git.Checkout-Extension.md)
+
+ 
+* [Git Clone](docs/Git.Clone-Extension.md)
+
+ 
+* [Git Commit](docs/Git.Commit-Extension.md)
+
+ 
+* [Git Diff](docs/Git.Diff-Extension.md)
+
+ 
+* [Git FileName](docs/Git.FileName-Extension.md)
+
+ 
+* [Git Grep](docs/Git.Grep-Extension.md)
+
+ 
+* [Git Help All](docs/Git.Help.All-Extension.md)
+
+ 
+* [Git Init](docs/Git.Init-Extension.md)
+
+ 
+* [Git Log](docs/Git.Log-Extension.md)
+
+ 
+* [Git Mv](docs/Git.Mv-Extension.md)
+
+ 
+* [Git Pull](docs/Git.Pull-Extension.md)
+
+ 
+* [Git Push](docs/Git.Push-Extension.md)
+
+ 
+* [Git RefLog](docs/Git.RefLog-Extension.md)
+
+ 
+* [Git Remote](docs/Git.Remote-Extension.md)
+
+ 
+* [Git Rm](docs/Git.Rm-Extension.md)
+
+ 
+* [Git Shortlog](docs/Git.Shortlog-Extension.md)
+
+ 
+* [Git Stash](docs/Git.Stash-Extension.md)
+
+ 
+* [Git Status](docs/Git.Status-Extension.md)
+
+
+
+### Additional Output Extensions
+
+A few extensions handle output from any number of git commands, depending on the arguments.
+
+* Git.FileName
+
+This applies to any git command that uses --name-only.
+It will attempt to return the name as a file, or as an object containing the name.
+
+* Git.FileOutput
+
+This applies to an git command that uses the -o flag.
+It will attempt to locate any output specified by -o and return it as a file or directory.
+
+## Use-Git Extensions
+
+ugit also allows you to extend the input for git.
+
+
+* [Git Clone Input](docs/Git.Clone.Input-Extension.md)
+
+
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <div align='center'>
-<img src='assets/ugit.svg' />
+<img src='assets/ugit.svg' alt='ugit' />
+<a href='https://www.powershellgallery.com/packages/ugit/'>
+<img src='https://img.shields.io/powershellgallery/dt/ugit' />
+</a>
 </div>
 
 Updated Git: A powerful PowerShell wrapper for git that lets you extend git, automate multiple repos, and output git as objects.
@@ -13,10 +16,12 @@ This enables _a lot_ of interesting scenarios, giving you and updated way to wor
 
 ## Getting started
 
-### Installing ugit
 ~~~PowerShell
+# Install ugit from the PowerShell Gallery
 Install-Module ugit -Scope CurrentUser
+# Then import it.
 Import-Module ugit -Force -PassThru
+
 # Once you've imported ugit, just run git commands normally.
 # If ugit has an extension for the command, it will output as an object.
 # These objects can be formatted by PowerShell
@@ -26,7 +31,6 @@ git log -n 5
 git log -n 5 |
   Get-Member
 ~~~
-
 
 ## How ugit works:
 
@@ -62,7 +66,11 @@ If this pattern matches the given git command, the extension will run.
 
 Get-UGitExtension is built using [Piecemeal](https://github.com/StartAutomating/Piecemeal)
 
-## Git Commands Extended
+## Out-Git Extensions
+
+### Git Commands
+
+Most extensions handle output from a single git command.
 
 
 * [Git Branch](docs/Git.Branch-Extension.md)
@@ -123,7 +131,9 @@ Get-UGitExtension is built using [Piecemeal](https://github.com/StartAutomating/
 
 
 
-### Extensions that may apply to any git command:
+### Additional Output Extensions
+
+A few extensions handle output from any number of git commands, depending on the arguments.
 
 * Git.FileName
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ You might want to try giving some of these a try.
     git clone https://github.com/Azure/azure-quickstart-templates --progress
 ~~~
 
+### Git.Commit.Input Example 1
+
+
+~~~PowerShell
+    git commit -Title "Fixing Something"
+~~~
+
+### Git.Commit.Input Example 2
+
+
+~~~PowerShell
+    git commit -Title "Changing Stuff" -Trailers @{"Co-Authored-By"="SOMEONE ELSE <Someone@Else.com>"}
+~~~
+
 ### Git.Commit Example 1
 
 
@@ -447,6 +461,9 @@ ugit also allows you to extend the input for git.
 
 
 * [Git Clone Input](docs/Git.Clone.Input-Extension.md)
+
+ 
+* [Git Commit Input](docs/Git.Commit.Input-Extension.md)
 
  
 * [Git Log Input](docs/Git.Log.Input-Extension.md)

--- a/README.md
+++ b/README.md
@@ -182,6 +182,13 @@ You might want to try giving some of these a try.
     git init # Initialize the current directory as a repository
 ~~~
 
+### Git.Log.Input Example 1
+
+
+~~~PowerShell
+    git log -CurrentBranch
+~~~
+
 ### Git.Log Example 1
 
 
@@ -440,6 +447,9 @@ ugit also allows you to extend the input for git.
 
 
 * [Git Clone Input](docs/Git.Clone.Input-Extension.md)
+
+ 
+* [Git Log Input](docs/Git.Log.Input-Extension.md)
 
 
 

--- a/README.ps1.md
+++ b/README.ps1.md
@@ -72,6 +72,7 @@ ugit comes packed with many examples.
 You might want to try giving some of these a try.
 
 ~~~PipeScript {
+   $null = Import-Module .\ugit.psd1 -Global
     @(foreach ($ugitExt in Get-UGitExtension) {
         $examples = @($ugitExt.Examples)        
         for ($exampleNumber = 1; $exampleNumber -le $examples.Length; $exampleNumber++) {
@@ -91,8 +92,7 @@ You might want to try giving some of these a try.
 
 Most extensions handle output from a single git command.
 
-~~~PipeScript {
-  $null = Import-Module .\ugit.psd1 -Global
+~~~PipeScript {  
   Get-UGitExtension -CommandName Out-Git |
     Where-Object DisplayName -notIn 'Git.FileOutput' |
     .InputObject {
@@ -119,8 +119,7 @@ It will attempt to locate any output specified by -o and return it as a file or 
 
 ugit also allows you to extend the input for git.
 
-~~~PipeScript {
-  $null = Import-Module .\ugit.psd1 -Global
+~~~PipeScript {  
   Get-UGitExtension -CommandName Use-Git |
     .InputObject {
       "[$($_.DisplayName -replace '\.', ' ')]($('docs/' + $_.DisplayName + '-Extension.md'))"

--- a/README.ps1.md
+++ b/README.ps1.md
@@ -66,6 +66,25 @@ If this pattern matches the given git command, the extension will run.
 
 Get-UGitExtension is built using [Piecemeal](https://github.com/StartAutomating/Piecemeal)
 
+## ugit examples
+
+ugit comes packed with many examples.
+You might want to try giving some of these a try.
+
+~~~PipeScript {
+    @(foreach ($ugitExt in Get-UGitExtension) {
+        $examples = @($ugitExt.Examples)        
+        for ($exampleNumber = 1; $exampleNumber -le $examples.Length; $exampleNumber++) {
+            @("### $($ugitExt.DisplayName) Example $($exampleNumber)", 
+                [Environment]::Newline,
+                "~~~PowerShell",                
+                $examples[$exampleNumber - 1],                
+                "~~~") -join [Environment]::Newline
+        }        
+    }) -join ([Environment]::Newline * 2)
+}
+~~~
+
 ## Out-Git Extensions
 
 ### Git Commands
@@ -96,20 +115,16 @@ It will attempt to return the name as a file, or as an object containing the nam
 This applies to an git command that uses the -o flag.
 It will attempt to locate any output specified by -o and return it as a file or directory.
 
+## Use-Git Extensions
 
-## ugit examples
+ugit also allows you to extend the input for git.
 
 ~~~PipeScript {
-    @(foreach ($ugitExt in Get-UGitExtension) {
-        $examples = @($ugitExt.Examples)        
-        for ($exampleNumber = 1; $exampleNumber -le $examples.Length; $exampleNumber++) {
-            @("### $($ugitExt.DisplayName) Example $($exampleNumber)", 
-                [Environment]::Newline,
-                "~~~PowerShell",                
-                $examples[$exampleNumber - 1],                
-                "~~~") -join [Environment]::Newline
-        }        
-    }) -join ([Environment]::Newline * 2)
+  $null = Import-Module .\ugit.psd1 -Global
+  Get-UGitExtension -CommandName Use-Git |
+    .InputObject {
+      "[$($_.DisplayName -replace '\.', ' ')]($('docs/' + $_.DisplayName + '-Extension.md'))"
+    } .BulletPoint = { $true }
 }
 ~~~
 

--- a/README.ps1.md
+++ b/README.ps1.md
@@ -1,5 +1,8 @@
 <div align='center'>
-<img src='assets/ugit.svg' />
+<img src='assets/ugit.svg' alt='ugit' />
+<a href='https://www.powershellgallery.com/packages/ugit/'>
+<img src='https://img.shields.io/powershellgallery/dt/ugit' />
+</a>
 </div>
 
 Updated Git: A powerful PowerShell wrapper for git that lets you extend git, automate multiple repos, and output git as objects.
@@ -13,10 +16,12 @@ This enables _a lot_ of interesting scenarios, giving you and updated way to wor
 
 ## Getting started
 
-### Installing ugit
 ~~~PowerShell
+# Install ugit from the PowerShell Gallery
 Install-Module ugit -Scope CurrentUser
+# Then import it.
 Import-Module ugit -Force -PassThru
+
 # Once you've imported ugit, just run git commands normally.
 # If ugit has an extension for the command, it will output as an object.
 # These objects can be formatted by PowerShell
@@ -26,7 +31,6 @@ git log -n 5
 git log -n 5 |
   Get-Member
 ~~~
-
 
 ## How ugit works:
 
@@ -62,11 +66,15 @@ If this pattern matches the given git command, the extension will run.
 
 Get-UGitExtension is built using [Piecemeal](https://github.com/StartAutomating/Piecemeal)
 
-## Git Commands Extended
+## Out-Git Extensions
+
+### Git Commands
+
+Most extensions handle output from a single git command.
 
 ~~~PipeScript {
   $null = Import-Module .\ugit.psd1 -Global
-  Get-UGitExtension |
+  Get-UGitExtension -CommandName Out-Git |
     Where-Object DisplayName -notIn 'Git.FileOutput' |
     .InputObject {
       "[$($_.DisplayName -replace '\.', ' ')]($('docs/' + $_.DisplayName + '-Extension.md'))"
@@ -74,7 +82,9 @@ Get-UGitExtension is built using [Piecemeal](https://github.com/StartAutomating/
 }
 ~~~
 
-### Extensions that may apply to any git command:
+### Additional Output Extensions
+
+A few extensions handle output from any number of git commands, depending on the arguments.
 
 * Git.FileName
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.3.8:
+
+* Use-Git can now be extended (#140, #97), letting you add PowerShell parameters to any git command
+* Initial input extensions
+  * git.clone.input (#141) (--progress is inferred so Write-Progress happens automagically)
+  * git.log.input (#142) (Added -Before/-After/-Author/-CurrentBranch)
+  * git.commit.input (#144) (Added -Message/-Body/-Title/-Trailer)
+* Other Improvements:
+  * git log will not process --pretty/--format (Fixes #143)
+  * git log now supports .Trailers (Fixes #112)
+  * git remote formatting improved (Fixes #145)
+  * git remote now works for multiple remotes (Fixes #136)
+  * Updated logo (#139)
+
+---
+
 ## 0.3.7:
 
 * git remote

--- a/docs/Git.Branch-Extension.md
+++ b/docs/Git.Branch-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Branch.UGit.Extension.ps1
 ----------------------------------------
 
@@ -62,7 +61,3 @@ git branch |                                          # Get all branches
 ```PowerShell
 Extensions/Git.Branch.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Checkout-Extension.md
+++ b/docs/Git.Checkout-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Checkout.UGit.Extension.ps1
 ------------------------------------------
 
@@ -42,7 +41,3 @@ git checkout main
 ```PowerShell
 Extensions/Git.Checkout.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Clone-Extension.md
+++ b/docs/Git.Clone-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Clone.UGit.Extension.ps1
 ---------------------------------------
 
@@ -55,7 +54,3 @@ git clone https://github.com/Azure/azure-quickstart-templates --progress
 ```PowerShell
 Extensions/Git.Clone.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Clone.Input-Extension.md
+++ b/docs/Git.Clone.Input-Extension.md
@@ -1,0 +1,40 @@
+Extensions/Git.Clone.Input.UGit.Extension.ps1
+---------------------------------------------
+
+
+
+
+### Synopsis
+Git Clone extended input
+
+
+
+---
+
+
+### Description
+
+Extends the input for git clone.
+
+By default, if --progress is not found, it will be added to any git clone.
+
+
+
+---
+
+
+### Examples
+#### EXAMPLE 1
+```PowerShell
+git clone https://github.com/MDN/content.git # This is a big repo.  Progress bars will be very welcome.
+```
+
+
+
+---
+
+
+### Syntax
+```PowerShell
+Extensions/Git.Clone.Input.UGit.Extension.ps1 [<CommonParameters>]
+```

--- a/docs/Git.Commit-Extension.md
+++ b/docs/Git.Commit-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Commit.UGit.Extension.ps1
 ----------------------------------------
 
@@ -54,7 +53,3 @@ $commitMessage.Amend("Committing stuff") # that's better
 ```PowerShell
 Extensions/Git.Commit.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Commit.Input-Extension.md
+++ b/docs/Git.Commit.Input-Extension.md
@@ -1,0 +1,126 @@
+Extensions/Git.Commit.Input.UGit.Extension.ps1
+----------------------------------------------
+
+
+
+
+### Synopsis
+Git Commit Input
+
+
+
+---
+
+
+### Description
+
+Makes Git Commit easier to use from PowerShell by providing parameters for the -Message, -Title, -Body, and -Trailers
+
+
+
+---
+
+
+### Examples
+#### EXAMPLE 1
+```PowerShell
+git commit -Title "Fixing Something"
+```
+
+#### EXAMPLE 2
+```PowerShell
+"}
+```
+
+
+
+---
+
+
+### Parameters
+#### **Message**
+
+The message used for the commit
+
+
+
+
+
+
+|Type      |Required|Position|PipelineInput|
+|----------|--------|--------|-------------|
+|`[String]`|false   |named   |false        |
+
+
+
+#### **Title**
+
+The title of the commit.  If -Message is also provided, this will become part of the -Body
+
+
+
+
+
+
+|Type      |Required|Position|PipelineInput|
+|----------|--------|--------|-------------|
+|`[String]`|false   |named   |false        |
+
+
+
+#### **Body**
+
+The body of the commit.
+
+
+
+
+
+
+|Type      |Required|Position|PipelineInput|
+|----------|--------|--------|-------------|
+|`[String]`|false   |named   |false        |
+
+
+
+#### **Trailers**
+
+Any git trailers to add to the commit.
+git trailers are key-value pairs you can use to associate metadata with a commit.
+As this uses --trailer, this requires git version 2.33 or greater.
+
+
+
+
+
+
+|Type           |Required|Position|PipelineInput|Aliases                                   |
+|---------------|--------|--------|-------------|------------------------------------------|
+|`[IDictionary]`|false   |named   |false        |Trailer<br/>CommitMetadata<br/>GitMetadata|
+
+
+
+#### **Amend**
+
+If set, will amend an existing commit.
+
+
+
+
+
+
+|Type      |Required|Position|PipelineInput|
+|----------|--------|--------|-------------|
+|`[Switch]`|false   |named   |false        |
+
+
+
+
+
+---
+
+
+### Syntax
+```PowerShell
+Extensions/Git.Commit.Input.UGit.Extension.ps1 [-Message <String>] [-Title <String>] [-Body <String>] [-Trailers <IDictionary>] [-Amend] [<CommonParameters>]
+```

--- a/docs/Git.Diff-Extension.md
+++ b/docs/Git.Diff-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Diff.UGit.Extension.ps1
 --------------------------------------
 
@@ -40,7 +39,3 @@ Outputs git diff entries as objects
 ```PowerShell
 Extensions/Git.Diff.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.FileName-Extension.md
+++ b/docs/Git.FileName-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.FileName.UGit.Extension.ps1
 ------------------------------------------
 
@@ -58,7 +57,3 @@ git diff --name-only
 ```PowerShell
 Extensions/Git.FileName.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.FileOutput-Extension.md
+++ b/docs/Git.FileOutput-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.FileOutput.UGit.Extension.ps1
 --------------------------------------------
 
@@ -39,7 +38,3 @@ git archive -o My.zip
 ```PowerShell
 Extensions/Git.FileOutput.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Grep-Extension.md
+++ b/docs/Git.Grep-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Grep.UGit.Extension.ps1
 --------------------------------------
 
@@ -60,7 +59,3 @@ git grep '-i' example # look for all examples in the repository
 ```PowerShell
 Extensions/Git.Grep.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Help.All-Extension.md
+++ b/docs/Git.Help.All-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Help.All.UGit.Extension.ps1
 ------------------------------------------
 
@@ -53,7 +52,3 @@ git help --all
 ```PowerShell
 Extensions/Git.Help.All.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Help.All-Extension.md
+++ b/docs/Git.Help.All-Extension.md
@@ -56,3 +56,4 @@ Extensions/Git.Help.All.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Init-Extension.md
+++ b/docs/Git.Init-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Init.UGit.Extension.ps1
 --------------------------------------
 
@@ -48,7 +47,3 @@ git init # Initialize the current directory as a repository
 ```PowerShell
 Extensions/Git.Init.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Init-Extension.md
+++ b/docs/Git.Init-Extension.md
@@ -51,3 +51,4 @@ Extensions/Git.Init.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Log-Extension.md
+++ b/docs/Git.Log-Extension.md
@@ -84,3 +84,4 @@ Extensions/Git.Log.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Log-Extension.md
+++ b/docs/Git.Log-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Log.UGit.Extension.ps1
 -------------------------------------
 
@@ -81,7 +80,3 @@ git log --merges
 ```PowerShell
 Extensions/Git.Log.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Log.Input-Extension.md
+++ b/docs/Git.Log.Input-Extension.md
@@ -1,0 +1,128 @@
+Extensions/Git.Log.Input.UGit.Extension.ps1
+-------------------------------------------
+
+
+
+
+### Synopsis
+git log input
+
+
+
+---
+
+
+### Description
+
+Extends the parameters for git log, making it easier to use from PowerShell.
+
+Allows timeframe parameters to be tab-completed:
+* After/Since become --after
+* Before/Until become --before
+* Author/Committer become --author
+
+Adds -CurrentBranch, which gives the changes between the upstream branch and the current branch.
+
+Also adds -IssueNumber, which searchers for commits that reference particular issues.
+
+
+
+---
+
+
+### Examples
+#### EXAMPLE 1
+```PowerShell
+git log -CurrentBranch
+```
+
+
+
+---
+
+
+### Parameters
+#### **After**
+
+Gets logs after a given date
+
+
+
+
+
+
+|Type        |Required|Position|PipelineInput|Aliases|
+|------------|--------|--------|-------------|-------|
+|`[DateTime]`|false   |named   |false        |Since  |
+
+
+
+#### **Before**
+
+Gets before a given date
+
+
+
+
+
+
+|Type        |Required|Position|PipelineInput|Aliases|
+|------------|--------|--------|-------------|-------|
+|`[DateTime]`|false   |named   |false        |Until  |
+
+
+
+#### **Author**
+
+Gets lof from a given author or committer
+
+
+
+
+
+
+|Type      |Required|Position|PipelineInput|Aliases  |
+|----------|--------|--------|-------------|---------|
+|`[String]`|false   |named   |false        |Committer|
+
+
+
+#### **CurrentBranch**
+
+If set, will get all changes between the upstream branch and the current branch.
+
+
+
+
+
+
+|Type      |Required|Position|PipelineInput|Aliases                     |
+|----------|--------|--------|-------------|----------------------------|
+|`[Switch]`|false   |named   |false        |UpstreamDelta<br/>ThisBranch|
+
+
+
+#### **IssueNumber**
+
+One or more issue numbers.  Providing an issue number of 0 will find all log entries that reference an issue.
+
+
+
+
+
+
+|Type       |Required|Position|PipelineInput        |Aliases                                                                             |
+|-----------|--------|--------|---------------------|------------------------------------------------------------------------------------|
+|`[Int32[]]`|false   |named   |true (ByPropertyName)|ReferenceNumbers<br/>ReferenceNumber<br/>IssueNumbers<br/>WorkItemID<br/>WorkItemIDs|
+
+
+
+
+
+---
+
+
+### Syntax
+```PowerShell
+Extensions/Git.Log.Input.UGit.Extension.ps1 [-After <DateTime>] [-Before <DateTime>] [-Author <String>] [-CurrentBranch] [-IssueNumber <Int32[]>] [<CommonParameters>]
+```

--- a/docs/Git.Mv-Extension.md
+++ b/docs/Git.Mv-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Mv.UGit.Extension.ps1
 ------------------------------------
 
@@ -53,7 +52,3 @@ git mv .\OldName.txt .\NewName.txt --verbose
 ```PowerShell
 Extensions/Git.Mv.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Mv-Extension.md
+++ b/docs/Git.Mv-Extension.md
@@ -56,3 +56,4 @@ Extensions/Git.Mv.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Pull-Extension.md
+++ b/docs/Git.Pull-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Pull.UGit.Extension.ps1
 --------------------------------------
 
@@ -68,7 +67,3 @@ git pull
 ```PowerShell
 Extensions/Git.Pull.UGit.Extension.ps1 [[-GitOut] <String>] [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Pull-Extension.md
+++ b/docs/Git.Pull-Extension.md
@@ -71,3 +71,4 @@ Extensions/Git.Pull.UGit.Extension.ps1 [[-GitOut] <String>] [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Push-Extension.md
+++ b/docs/Git.Push-Extension.md
@@ -51,3 +51,4 @@ Extensions/Git.Push.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Push-Extension.md
+++ b/docs/Git.Push-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Push.UGit.Extension.ps1
 --------------------------------------
 
@@ -48,7 +47,3 @@ git push
 ```PowerShell
 Extensions/Git.Push.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.RefLog-Extension.md
+++ b/docs/Git.RefLog-Extension.md
@@ -51,3 +51,4 @@ Extensions/Git.RefLog.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.RefLog-Extension.md
+++ b/docs/Git.RefLog-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.RefLog.UGit.Extension.ps1
 ----------------------------------------
 
@@ -48,7 +47,3 @@ git reflog
 ```PowerShell
 Extensions/Git.RefLog.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Remote-Extension.md
+++ b/docs/Git.Remote-Extension.md
@@ -67,3 +67,4 @@ Extensions/Git.Remote.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Remote-Extension.md
+++ b/docs/Git.Remote-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Remote.UGit.Extension.ps1
 ----------------------------------------
 
@@ -64,7 +63,3 @@ git remote | git remote show
 ```PowerShell
 Extensions/Git.Remote.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Rm-Extension.md
+++ b/docs/Git.Rm-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Rm.UGit.Extension.ps1
 ------------------------------------
 
@@ -48,7 +47,3 @@ git rm .\FileIDontCareAbout.txt
 ```PowerShell
 Extensions/Git.Rm.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Rm-Extension.md
+++ b/docs/Git.Rm-Extension.md
@@ -51,3 +51,4 @@ Extensions/Git.Rm.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Shortlog-Extension.md
+++ b/docs/Git.Shortlog-Extension.md
@@ -55,3 +55,4 @@ Extensions/Git.Shortlog.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Shortlog-Extension.md
+++ b/docs/Git.Shortlog-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Shortlog.UGit.Extension.ps1
 ------------------------------------------
 
@@ -52,7 +51,3 @@ git shortlog --sumary --email # Get a shortlog summary, with email.
 ```PowerShell
 Extensions/Git.Shortlog.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Stash-Extension.md
+++ b/docs/Git.Stash-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Stash.UGit.Extension.ps1
 ---------------------------------------
 
@@ -37,7 +36,3 @@ git stash list
 ```PowerShell
 Extensions/Git.Stash.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/Git.Stash-Extension.md
+++ b/docs/Git.Stash-Extension.md
@@ -40,3 +40,4 @@ Extensions/Git.Stash.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Status-Extension.md
+++ b/docs/Git.Status-Extension.md
@@ -45,3 +45,4 @@ Extensions/Git.Status.UGit.Extension.ps1 [<CommonParameters>]
 
 
 
+

--- a/docs/Git.Status-Extension.md
+++ b/docs/Git.Status-Extension.md
@@ -1,4 +1,3 @@
-
 Extensions/Git.Status.UGit.Extension.ps1
 ----------------------------------------
 
@@ -42,7 +41,3 @@ git status | Select-Object -ExpandProperty Untracked
 ```PowerShell
 Extensions/Git.Status.UGit.Extension.ps1 [<CommonParameters>]
 ```
-
-
-
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -414,7 +414,3 @@ It will attempt to locate any output specified by -o and return it as a file or 
 ~~~PowerShell
     git status | Select-Object -ExpandProperty Untracked
 ~~~
-
-
-
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -179,6 +179,13 @@ It will attempt to locate any output specified by -o and return it as a file or 
     git checkout main
 ~~~
 
+### Git.Clone.Input Example 1
+
+
+~~~PowerShell
+    git clone https://github.com/MDN/content.git # This is a big repo.  Progress bars will be very welcome.
+~~~
+
 ### Git.Clone Example 1
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,6 +125,20 @@ You might want to try giving some of these a try.
     git clone https://github.com/Azure/azure-quickstart-templates --progress
 ~~~
 
+### Git.Commit.Input Example 1
+
+
+~~~PowerShell
+    git commit -Title "Fixing Something"
+~~~
+
+### Git.Commit.Input Example 2
+
+
+~~~PowerShell
+    git commit -Title "Changing Stuff" -Trailers @{"Co-Authored-By"="SOMEONE ELSE <Someone@Else.com>"}
+~~~
+
 ### Git.Commit Example 1
 
 
@@ -447,6 +461,9 @@ ugit also allows you to extend the input for git.
 
 
 * [Git Clone Input](Git.Clone.Input-Extension.md)
+
+ 
+* [Git Commit Input](Git.Commit.Input-Extension.md)
 
  
 * [Git Log Input](Git.Log.Input-Extension.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -417,3 +417,4 @@ It will attempt to locate any output specified by -o and return it as a file or 
 
 
 
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,8 @@
 <div align='center'>
-<img src='assets/ugit.svg' />
+<img src='assets/ugit.svg' alt='ugit' />
+<a href='https://www.powershellgallery.com/packages/ugit/'>
+<img src='https://img.shields.io/powershellgallery/dt/ugit' />
+</a>
 </div>
 
 Updated Git: A powerful PowerShell wrapper for git that lets you extend git, automate multiple repos, and output git as objects.
@@ -13,10 +16,12 @@ This enables _a lot_ of interesting scenarios, giving you and updated way to wor
 
 ## Getting started
 
-### Installing ugit
 ~~~PowerShell
+# Install ugit from the PowerShell Gallery
 Install-Module ugit -Scope CurrentUser
+# Then import it.
 Import-Module ugit -Force -PassThru
+
 # Once you've imported ugit, just run git commands normally.
 # If ugit has an extension for the command, it will output as an object.
 # These objects can be formatted by PowerShell
@@ -26,7 +31,6 @@ git log -n 5
 git log -n 5 |
   Get-Member
 ~~~
-
 
 ## How ugit works:
 
@@ -62,7 +66,11 @@ If this pattern matches the given git command, the extension will run.
 
 Get-UGitExtension is built using [Piecemeal](https://github.com/StartAutomating/Piecemeal)
 
-## Git Commands Extended
+## Out-Git Extensions
+
+### Git Commands
+
+Most extensions handle output from a single git command.
 
 
 * [Git Branch](Git.Branch-Extension.md)
@@ -123,7 +131,9 @@ Get-UGitExtension is built using [Piecemeal](https://github.com/StartAutomating/
 
 
 
-### Extensions that may apply to any git command:
+### Additional Output Extensions
+
+A few extensions handle output from any number of git commands, depending on the arguments.
 
 * Git.FileName
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -417,4 +417,3 @@ It will attempt to locate any output specified by -o and return it as a file or 
 
 
 
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,6 +182,13 @@ You might want to try giving some of these a try.
     git init # Initialize the current directory as a repository
 ~~~
 
+### Git.Log.Input Example 1
+
+
+~~~PowerShell
+    git log -CurrentBranch
+~~~
+
 ### Git.Log Example 1
 
 
@@ -440,3 +447,6 @@ ugit also allows you to extend the input for git.
 
 
 * [Git Clone Input](Git.Clone.Input-Extension.md)
+
+ 
+* [Git Log Input](Git.Log.Input-Extension.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,87 +66,10 @@ If this pattern matches the given git command, the extension will run.
 
 Get-UGitExtension is built using [Piecemeal](https://github.com/StartAutomating/Piecemeal)
 
-## Out-Git Extensions
-
-### Git Commands
-
-Most extensions handle output from a single git command.
-
-
-* [Git Branch](Git.Branch-Extension.md)
-
- 
-* [Git Checkout](Git.Checkout-Extension.md)
-
- 
-* [Git Clone](Git.Clone-Extension.md)
-
- 
-* [Git Commit](Git.Commit-Extension.md)
-
- 
-* [Git Diff](Git.Diff-Extension.md)
-
- 
-* [Git FileName](Git.FileName-Extension.md)
-
- 
-* [Git Grep](Git.Grep-Extension.md)
-
- 
-* [Git Help All](Git.Help.All-Extension.md)
-
- 
-* [Git Init](Git.Init-Extension.md)
-
- 
-* [Git Log](Git.Log-Extension.md)
-
- 
-* [Git Mv](Git.Mv-Extension.md)
-
- 
-* [Git Pull](Git.Pull-Extension.md)
-
- 
-* [Git Push](Git.Push-Extension.md)
-
- 
-* [Git RefLog](Git.RefLog-Extension.md)
-
- 
-* [Git Remote](Git.Remote-Extension.md)
-
- 
-* [Git Rm](Git.Rm-Extension.md)
-
- 
-* [Git Shortlog](Git.Shortlog-Extension.md)
-
- 
-* [Git Stash](Git.Stash-Extension.md)
-
- 
-* [Git Status](Git.Status-Extension.md)
-
-
-
-### Additional Output Extensions
-
-A few extensions handle output from any number of git commands, depending on the arguments.
-
-* Git.FileName
-
-This applies to any git command that uses --name-only.
-It will attempt to return the name as a file, or as an object containing the name.
-
-* Git.FileOutput
-
-This applies to an git command that uses the -o flag.
-It will attempt to locate any output specified by -o and return it as a file or directory.
-
-
 ## ugit examples
+
+ugit comes packed with many examples.
+You might want to try giving some of these a try.
 
 ### Git.Branch Example 1
 
@@ -431,3 +354,89 @@ It will attempt to locate any output specified by -o and return it as a file or 
 ~~~PowerShell
     git status | Select-Object -ExpandProperty Untracked
 ~~~
+
+## Out-Git Extensions
+
+### Git Commands
+
+Most extensions handle output from a single git command.
+
+
+* [Git Branch](Git.Branch-Extension.md)
+
+ 
+* [Git Checkout](Git.Checkout-Extension.md)
+
+ 
+* [Git Clone](Git.Clone-Extension.md)
+
+ 
+* [Git Commit](Git.Commit-Extension.md)
+
+ 
+* [Git Diff](Git.Diff-Extension.md)
+
+ 
+* [Git FileName](Git.FileName-Extension.md)
+
+ 
+* [Git Grep](Git.Grep-Extension.md)
+
+ 
+* [Git Help All](Git.Help.All-Extension.md)
+
+ 
+* [Git Init](Git.Init-Extension.md)
+
+ 
+* [Git Log](Git.Log-Extension.md)
+
+ 
+* [Git Mv](Git.Mv-Extension.md)
+
+ 
+* [Git Pull](Git.Pull-Extension.md)
+
+ 
+* [Git Push](Git.Push-Extension.md)
+
+ 
+* [Git RefLog](Git.RefLog-Extension.md)
+
+ 
+* [Git Remote](Git.Remote-Extension.md)
+
+ 
+* [Git Rm](Git.Rm-Extension.md)
+
+ 
+* [Git Shortlog](Git.Shortlog-Extension.md)
+
+ 
+* [Git Stash](Git.Stash-Extension.md)
+
+ 
+* [Git Status](Git.Status-Extension.md)
+
+
+
+### Additional Output Extensions
+
+A few extensions handle output from any number of git commands, depending on the arguments.
+
+* Git.FileName
+
+This applies to any git command that uses --name-only.
+It will attempt to return the name as a file, or as an object containing the name.
+
+* Git.FileOutput
+
+This applies to an git command that uses the -o flag.
+It will attempt to locate any output specified by -o and return it as a file or directory.
+
+## Use-Git Extensions
+
+ugit also allows you to extend the input for git.
+
+
+* [Git Clone Input](Git.Clone.Input-Extension.md)

--- a/docs/assets/ugit.svg
+++ b/docs/assets/ugit.svg
@@ -3,6 +3,9 @@
   <symbol id="psChevron" viewBox="0 0 100 100" preserveAspectRatio="False">
     <polygon points="40,20 45,20 60,50 35,80 32.5,80 55,50" />
   </symbol>
-  <use href="#psChevron" fill="#4488ff" x="120" y="37.5%" width="10%" height="25%" />
-  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-family="serif" fill="#4488ff">ugit</text>
+  <use href="#psChevron" fill="#4488ff" x="30%" y="37.5%" width="10%" height="25%" />
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="middle" font-family="serif" fill="#4488ff" font-size="4em">
+    <tspan font-size=".5em">u</tspan>
+    <tspan font-size="1em" dx="-.25em">git</tspan>
+  </text>
 </svg>

--- a/ugit.GitHubWorkflow.PSDevOps.ps1
+++ b/ugit.GitHubWorkflow.PSDevOps.ps1
@@ -1,7 +1,12 @@
 ﻿#requires -Module PSDevOps
 Push-Location $PSScriptRoot
 Import-BuildStep -ModuleName ugit
-New-GitHubWorkflow -Name "Analyze, Test, Tag, and Publish" -On Push, PullRequest, Demand -Job PowerShellStaticAnalysis, TestPowerShellOnLinux, TagReleaseAndPublish, buildugit |
-    Set-Content .\.github\workflows\TestAndPublish.yml -Encoding UTF8 -PassThru
+New-GitHubWorkflow -Name "Analyze, Test, Tag, and Publish" -On Push, PullRequest, Demand -Job PowerShellStaticAnalysis, 
+    TestPowerShellOnLinux, 
+    TagReleaseAndPublish, 
+    buildugit -OutputPath .\.github\workflows\TestAndPublish.yml
+
+New-GitHubWorkflow -On Issue, 
+    Demand -Job RunGitPub -Name OnIssueChanged -OutputPath .\.github\workflows\OnIssue.yml
 
 Pop-Location

--- a/ugit.format.ps1xml
+++ b/ugit.format.ps1xml
@@ -2186,27 +2186,51 @@ $BackgroundColor
         )
     </ScriptBlock>
               </ExpressionBinding>
-              <NewLine />
-              <Text>  Remote Branches:</Text>
-              <NewLine />
               <ExpressionBinding>
+                <ItemSelectionCondition>
+                  <ScriptBlock> $_.RemoteBranches </ScriptBlock>
+                </ItemSelectionCondition>
+                <ScriptBlock>
+        [Environment]::NewLine +  '  Remote Branches:' + [Environment]::NewLine
+    </ScriptBlock>
+              </ExpressionBinding>
+              <ExpressionBinding>
+                <ItemSelectionCondition>
+                  <ScriptBlock> $_.RemoteBranches </ScriptBlock>
+                </ItemSelectionCondition>
                 <PropertyName>RemoteBranches</PropertyName>
                 <CustomControlName>GitRemoteBranchList</CustomControlName>
               </ExpressionBinding>
-              <NewLine />
-              <Text>  Local Branches:</Text>
-              <NewLine />
               <ExpressionBinding>
+                <ItemSelectionCondition>
+                  <ScriptBlock> $_.LocalBranches </ScriptBlock>
+                </ItemSelectionCondition>
+                <ScriptBlock>
+        [Environment]::NewLine +  '  Local Branches:' + [Environment]::NewLine
+    </ScriptBlock>
+              </ExpressionBinding>
+              <ExpressionBinding>
+                <ItemSelectionCondition>
+                  <ScriptBlock> $_.LocalBranches </ScriptBlock>
+                </ItemSelectionCondition>
                 <PropertyName>LocalBranches</PropertyName>
                 <CustomControlName>GitRemoteBranchList</CustomControlName>
               </ExpressionBinding>
-              <Text>  Tracked Upstreams:</Text>
-              <NewLine />
               <ExpressionBinding>
+                <ItemSelectionCondition>
+                  <ScriptBlock> $_.TrackedUpstreams </ScriptBlock>
+                </ItemSelectionCondition>
+                <ScriptBlock>
+        [Environment]::NewLine +  '  Tracked Upstreams:' + [Environment]::NewLine
+    </ScriptBlock>
+              </ExpressionBinding>
+              <ExpressionBinding>
+                <ItemSelectionCondition>
+                  <ScriptBlock> $_.TrackedUpstreams </ScriptBlock>
+                </ItemSelectionCondition>
                 <PropertyName>TrackedUpstreams</PropertyName>
                 <CustomControlName>GitRemoteBranchList</CustomControlName>
               </ExpressionBinding>
-              <NewLine />
             </CustomItem>
           </CustomEntry>
         </CustomEntries>

--- a/ugit.psd1
+++ b/ugit.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion    = '0.3.7'
+    ModuleVersion    = '0.3.8'
     RootModule       = 'ugit.psm1'
     FormatsToProcess = 'ugit.format.ps1xml'
     TypesToProcess   = 'ugit.types.ps1xml'
@@ -17,6 +17,22 @@ PrivateData   = @{
         LicenseURI = 'https://github.com/StartAutomating/ugit/blob/main/LICENSE'
         BuildModule  = @('EZOut', 'Piecemeal', 'PipeScript')
         ReleaseNotes = @'
+## 0.3.8:
+
+* Use-Git can now be extended (#140, #97), letting you add PowerShell parameters to any git command
+* Initial input extensions
+  * git.clone.input (#141) (--progress is inferred so Write-Progress happens automagically)
+  * git.log.input (#142) (Added -Before/-After/-Author/-CurrentBranch)
+  * git.commit.input (#144) (Added -Message/-Body/-Title/-Trailer)
+* Other Improvements:
+  * git log will not process --pretty/--format (Fixes #143)
+  * git log now supports .Trailers (Fixes #112)
+  * git remote formatting improved (Fixes #145)
+  * git remote now works for multiple remotes (Fixes #136)
+  * Updated logo (#139)
+
+---
+
 ## 0.3.7:
 
 * git remote


### PR DESCRIPTION
## 0.3.8:

* Use-Git can now be extended (#140, #97), letting you add PowerShell parameters to any git command
* Initial input extensions
  * git.clone.input (#141) (--progress is inferred so Write-Progress happens automagically)
  * git.log.input (#142) (Added -Before/-After/-Author/-CurrentBranch)
  * git.commit.input (#144) (Added -Message/-Body/-Title/-Trailer)
* Other Improvements:
  * git log will not process --pretty/--format (Fixes #143)
  * git log now supports .Trailers (Fixes #112)
  * git remote formatting improved (Fixes #145)
  * git remote now works for multiple remotes (Fixes #136)
  * Updated logo (#139)

---