### PR TITLE
fix: `ugit.Piecemeal.ps1` requires error statement

### DIFF
--- a/Build/ugit.Piecemeal.ps1
+++ b/Build/ugit.Piecemeal.ps1
@@ -1,4 +1,4 @@
-#require -Module Piecemeal
+#requires -Module Piecemeal
 Push-Location ($PSScriptRoot | Split-Path | Join-Path -ChildPath "Commands")
 
 Install-Piecemeal -ExtensionModule 'ugit' -ExtensionModuleAlias 'git' -ExtensionNoun 'UGitExtension' -ExtensionTypeName 'ugit.extension' -OutputPath '.\Get-UGitExtension.ps1'


### PR DESCRIPTION
A small typo caused the script to not load the module piecemeal. 
TIL `#require` fails silently, there's no parsing error.

Fixes: #344 